### PR TITLE
Allow stack keyword needed by modern pygmentize

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,30 @@ A custom C++-lexer for [Pygments](http://pygments.org/), for extra keyword highl
 
 ## Install
 
-    $ git clone https://github.com/FSund/pygments-custom-cpplexer.git
-    $ cd pygments-custom-cpplexer
-    $ (sudo) python setup.py install
+    git clone https://github.com/FSund/pygments-custom-cpplexer.git
+    cd pygments-custom-cpplexer
+    (sudo) python setup.py install
 
 ### Verify
 
 Verify that the package installed correctly by looking for the lexer "mdcpp" in the output of
 
-    $ pygmentize -L lexers
+    pygmentize -L lexers
 
 ## Using the lexer in latex
 
 Just use the **mdcpp** "language". In LaTeX this means something like this
 
-    \begin{minted}{mdcpp}
-    vec3 position(0.0, 0.0, 0.0);
-    Atom *atom = new Atom(position);
-    \end{minted}
+``` latex
+\begin{minted}{mdcpp}
+vec3 position(0.0, 0.0, 0.0);
+Atom *atom = new Atom(position);
+\end{minted}
+
+```
+
+You can test it using the [example.ltx](example.ltx) file like so:
+
+    pdflatex -shell-escape example.ltx
 
 See the minted package at https://github.com/gpoore/minted for more information.

--- a/example.ltx
+++ b/example.ltx
@@ -1,0 +1,18 @@
+\documentclass{book}
+\usepackage{minted}
+
+\begin{document}
+
+\section{Before}
+\begin{minted}{cpp}
+vec3 position(0.0, 0.0, 0.0);
+Atom *atom = Atom(position);
+\end{minted}
+
+\section{After}
+\begin{minted}{mdcpp}
+vec3 position(0.0, 0.0, 0.0);
+Atom *atom = Atom(position);
+\end{minted}
+
+\end{document}

--- a/pygments_mdcpp/__init__.py
+++ b/pygments_mdcpp/__init__.py
@@ -1,4 +1,3 @@
-#from pygments.lexers.asm import CppLexer
 from pygments.lexers.compiled import CppLexer
 from pygments.token import Name, Keyword
 
@@ -6,11 +5,11 @@ class MDCppLexer(CppLexer):
     name = 'MDCpp'
     aliases = ['mdcpp']
 
-    EXTRA_KEYWORDS = ['Atom', 'System', 'vec3']
+    EXTRA_TYPES = ['Atom', 'System', 'vec3']
 
-    def get_tokens_unprocessed(self, text):
-        for index, token, value in CppLexer.get_tokens_unprocessed(self, text):
-            if token is Name and value in self.EXTRA_KEYWORDS:
-                yield index, Keyword, value
-            else:
-                yield index, token, value
+    def get_tokens_unprocessed(self, text, stack=('root',)):
+        for index, token, value in CppLexer.get_tokens_unprocessed(self, text, stack):
+            if token is Name:
+                if value in self.EXTRA_TYPES:
+                    token=Keyword.Type
+            yield index, token, value


### PR DESCRIPTION
Also syntax highlight `vec3`, etc, as Keyword.Type instead of generic Keywords. 

Add example latex file.